### PR TITLE
Fix the find method of the Card model.

### DIFF
--- a/src/Models/Card.php
+++ b/src/Models/Card.php
@@ -16,12 +16,9 @@ class Card extends Model
      */
     public function find(string $pokemonTcgId): mixed
     {
-        return $this->resolveResponse(
-            $this->client->get($this->getEndpoint(), [
-                'id' => $pokemonTcgId,
-            ]),
-            $this->getEndpoint().$pokemonTcgId
-        );
+        $endpoint = $this->getEndpoint() . '/' . $pokemonTcgId;
+    
+        return $this->resolveResponse($this->client->get($endpoint), $endpoint);
     }
 
     /**


### PR DESCRIPTION
Currently the find method returns a set of multiple cards, because currently the endpoint is looked up with `cards?id=<id>`.

The [documentation](https://docs.pokemontcg.io/api-reference/cards/get-card) states that the endpoint is `cards/<id>`.

This change has the same behavior as the find method on the Sets model.